### PR TITLE
Remove extraneous print

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -37,7 +37,7 @@ def main():
 
             import pyperclip
 
-            print(pyperclip.copy(convert(str(input("Enter the Shared Link: ")))))
+            pyperclip.copy(convert(str(input("Enter the Shared Link: "))))
 
             pyperclip.paste()
 


### PR DESCRIPTION
`pyperclip.copy()` apparently returns `None` (or potentially doesn't have a return), which is being passed to `print()`.

This pull request closes #1.